### PR TITLE
change extent default basemap ID to lambert

### DIFF
--- a/src/components/helpers/extent.vue
+++ b/src/components/helpers/extent.vue
@@ -136,7 +136,7 @@ const rampConfig = {
             }
           }
         ],
-        initialBasemapId: 'baseEsriWorld'
+        initialBasemapId: 'baseNrCan'
       },
       layers: [],
       fixtures: {


### PR DESCRIPTION
Closes #33 

Changes the extent picker default basemap from Mercator to Lambert.