### PR TITLE
NPM script stopper

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# stop rando scripts in hacked packages from running
+ignore-scripts=true


### PR DESCRIPTION
### Changes
- Prevents scripts in NPM packages from running

### Notes

See https://github.com/ramp4-pcar4/ramp4-pcar4/pull/2777 for reasoning & goals.

### Testing

Have done the following and things appeared to work as expected:
- `npm install`
- `npm run dev`
- `npm run build`

 