### PR TITLE
upload screen and tailwind fixes

### DIFF
--- a/index-ca-en.html
+++ b/index-ca-en.html
@@ -68,7 +68,7 @@
                 display: flex;
                 flex-direction: column;
                 padding: 8px;
-                height: calc(100vh - 64px);
+                height: calc(100vh - 32px);
                 gap: 16px;
             }
             #app {

--- a/index-ca-fr.html
+++ b/index-ca-fr.html
@@ -67,7 +67,7 @@
                 display: flex;
                 flex-direction: column;
                 padding: 8px;
-                height: calc(100vh - 64px);
+                height: calc(100vh - 32px);
                 gap: 16px;
             }
             #app {

--- a/src/components/fixtures/fixtures.vue
+++ b/src/components/fixtures/fixtures.vue
@@ -28,7 +28,7 @@ const { t } = useI18n();
 
 <template>
     <div>
-        <h1 class="text-2xl font-semibold">{{ t('navbar.fixtures') }}</h1>
+        <h3 class="text-2xl font-semibold">{{ t('navbar.fixtures') }}</h3>
         <Appbar v-model="store.elc.fixtures.appbar" />
         <AreasOfInterest v-model="store.elc.fixtures['areas-of-interest']" />
         <Basemap v-model="store.elc.fixtures.basemap" />

--- a/src/components/helpers/checkbox.vue
+++ b/src/components/helpers/checkbox.vue
@@ -23,7 +23,7 @@ const onInput = (e: Event) => {
 </script>
 
 <template>
-    <div class="mt-4 flex items-center">
+    <div class="mt-16 flex items-center">
         <input type="checkbox" :disabled="disabled ?? false" :checked="checked" :aria-label="title" @input="onInput" />
         <InputHeader :title="title" :description="description" type="checkbox" />
     </div>

--- a/src/components/helpers/collapsible.vue
+++ b/src/components/helpers/collapsible.vue
@@ -13,7 +13,7 @@ defineProps(['title', 'description', 'thickBorder', 'required']);
 </script>
 
 <template>
-    <div class="mt-4 p-3 border-black rounded-md" :class="{ 'border-2': thickBorder, border: !thickBorder }" ref="el">
+    <div class="mt-8 p-6 border-black rounded-md" :class="{ 'border-2': thickBorder, border: !thickBorder }" ref="el">
         <div
             class="flex items-center cursor-pointer"
             @click="
@@ -31,7 +31,7 @@ defineProps(['title', 'description', 'thickBorder', 'required']);
                 <button
                     :content="t('editor.expand')"
                     v-tippy="{ trigger: 'mouseenter focus' }"
-                    class="mr-1 sm:mr-3"
+                    class="mr-2 ce-sm:mr-6"
                     :aria-label="t('editor.expand')"
                 >
                     <svg
@@ -48,8 +48,8 @@ defineProps(['title', 'description', 'thickBorder', 'required']);
             </slot>
         </div>
         <div v-if="expanded">
-            <hr class="border-solid border-t border-gray-300 my-2" />
-            <div class="mt-4"><slot></slot></div>
+            <hr class="border-solid border-t border-gray-300 my-8" />
+            <div class="mt-8"><slot></slot></div>
         </div>
     </div>
 </template>

--- a/src/components/helpers/collapsible.vue
+++ b/src/components/helpers/collapsible.vue
@@ -13,7 +13,7 @@ defineProps(['title', 'description', 'thickBorder', 'required']);
 </script>
 
 <template>
-    <div class="mt-8 p-6 border-black rounded-md" :class="{ 'border-2': thickBorder, border: !thickBorder }" ref="el">
+    <div class="mt-8 p-6" ref="el">
         <div
             class="flex items-center cursor-pointer"
             @click="
@@ -48,8 +48,7 @@ defineProps(['title', 'description', 'thickBorder', 'required']);
             </slot>
         </div>
         <div v-if="expanded">
-            <hr class="border-solid border-t border-gray-300 my-8" />
-            <div class="mt-8"><slot></slot></div>
+            <div class="mt-8 border-l-2 pl-8"><slot></slot></div>
         </div>
     </div>
 </template>

--- a/src/components/helpers/extent.vue
+++ b/src/components/helpers/extent.vue
@@ -215,7 +215,7 @@ const onInput = (key: string, val: string): void => {
 
 <template>
     <Collapsible :title="props.title" :required="required" :description="description">
-        <div ref="rampInstance" class="w-full max-w-2xl h-96"></div>
+        <div ref="rampInstance" class="w-full h-[400px]"></div>
         <button @click="saveExtent" class="mt-2 bg-black text-white p-1 hover:bg-gray-800">
             {{ t('extent.save') }}
         </button>

--- a/src/components/helpers/input-header.vue
+++ b/src/components/helpers/input-header.vue
@@ -34,6 +34,7 @@ defineProps({
         </p>
         <button
             v-if="!!description"
+            class="pl-4"
             :content="description"
             :aria-label="description"
             v-tippy="{
@@ -42,7 +43,7 @@ defineProps({
             }"
             @click.stop
         >
-            <svg class="fill-current w-20 h-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <svg class="fill-current w-16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                 <path d="M0 0h24v24H0z" fill="none"></path>
                 <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"

--- a/src/components/helpers/input-header.vue
+++ b/src/components/helpers/input-header.vue
@@ -42,7 +42,7 @@ defineProps({
             }"
             @click.stop
         >
-            <svg class="fill-current w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <svg class="fill-current w-20 h-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                 <path d="M0 0h24v24H0z" fill="none"></path>
                 <path
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"

--- a/src/components/helpers/list.vue
+++ b/src/components/helpers/list.vue
@@ -231,7 +231,7 @@ const fieldToInputType: { [key: string]: string } = {
                                             viewBox="0 0 24 24"
                                             stroke-width="1.5"
                                             stroke="currentColor"
-                                            class="w-6 h-6"
+                                            class="w-20 h-20"
                                         >
                                             <path
                                                 stroke-linecap="round"
@@ -250,9 +250,10 @@ const fieldToInputType: { [key: string]: string } = {
                                             v-if="['string', 'number', 'boolean'].includes(field.type)"
                                             :type="fieldToInputType[field.type]"
                                             :disabled="editDisabled"
+                                            class="text-base"
                                             :class="{
                                                 'w-full max-w-xs': field.type !== 'boolean',
-                                                'cursor-pointer': field.type === 'boolean'
+                                                'cursor-pointer w-16 h-16': field.type === 'boolean'
                                             }"
                                             v-model="list[index][field.property]"
                                             v-bind:checked="field.type === 'boolean' ? field.checked : undefined"
@@ -280,7 +281,7 @@ const fieldToInputType: { [key: string]: string } = {
                                             :type="fieldToInputType[field.type]"
                                             :class="{
                                                 'w-full max-w-xs': field.type.toLowerCase() !== 'boolean',
-                                                'cursor-pointer': field.type.toLowerCase() === 'boolean'
+                                                'cursor-pointer w-16 h-16': field.type.toLowerCase() === 'boolean'
                                             }"
                                             :aria-label="t(field.title)"
                                             :disabled="editDisabled"
@@ -313,7 +314,7 @@ const fieldToInputType: { [key: string]: string } = {
                                                 viewBox="0 0 24 24"
                                                 stroke-width="1.5"
                                                 stroke="currentColor"
-                                                class="w-6 h-6"
+                                                class="w-20"
                                             >
                                                 <path
                                                     stroke-linecap="round"
@@ -337,7 +338,7 @@ const fieldToInputType: { [key: string]: string } = {
                                                     viewBox="0 0 24 24"
                                                     stroke-width="1.5"
                                                     stroke="currentColor"
-                                                    class="w-6 h-6"
+                                                    class="w-20"
                                                 >
                                                     <path
                                                         stroke-linecap="round"
@@ -360,7 +361,7 @@ const fieldToInputType: { [key: string]: string } = {
                                                     viewBox="0 0 24 24"
                                                     stroke-width="1.5"
                                                     stroke="currentColor"
-                                                    class="w-6 h-6"
+                                                    class="w-20"
                                                 >
                                                     <path
                                                         stroke-linecap="round"
@@ -381,7 +382,7 @@ const fieldToInputType: { [key: string]: string } = {
                                     <button
                                         :disabled="editDisabled"
                                         :class="{ handle: !editDisabled }"
-                                        class="cursor-move disabled:text-gray-500 disabled:cursor-not-allowed mr-1 ce-sm:mr-3"
+                                        class="cursor-move disabled:text-gray-500 disabled:cursor-not-allowed mr-4 ce-sm:mr-12"
                                         @click.stop
                                         :content="t('editor.reorder')"
                                         v-tippy
@@ -393,7 +394,7 @@ const fieldToInputType: { [key: string]: string } = {
                                             viewBox="0 0 24 24"
                                             stroke-width="1.5"
                                             stroke="currentColor"
-                                            class="w-6 h-6"
+                                            class="w-20"
                                         >
                                             <path
                                                 stroke-linecap="round"
@@ -405,7 +406,7 @@ const fieldToInputType: { [key: string]: string } = {
                                     <button
                                         :content="t('editor.expand')"
                                         v-tippy
-                                        class="mr-1 ce-sm:mr-3 arrow"
+                                        class="mr-4 ce-sm:mr-12 arrow"
                                         :aria-label="t('editor.expand')"
                                     >
                                         <svg
@@ -417,7 +418,7 @@ const fieldToInputType: { [key: string]: string } = {
                                             <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
                                         </svg>
                                     </button>
-                                    <span class="mr-1 ce-sm:mr-5 ce-sm:text-lg">{{
+                                    <span class="mr-4 ce-sm:mr-20 ce-sm:text-lg">{{
                                         list[index].id ||
                                         list[index].name ||
                                         list[index].layerId ||
@@ -442,7 +443,7 @@ const fieldToInputType: { [key: string]: string } = {
                                                 viewBox="0 0 24 24"
                                                 stroke-width="1.5"
                                                 stroke="currentColor"
-                                                class="w-6 h-6"
+                                                class="w-20"
                                             >
                                                 <path
                                                     stroke-linecap="round"
@@ -466,7 +467,7 @@ const fieldToInputType: { [key: string]: string } = {
                                                     viewBox="0 0 24 24"
                                                     stroke-width="1.5"
                                                     stroke="currentColor"
-                                                    class="w-6 h-6"
+                                                    class="w-20"
                                                 >
                                                     <path
                                                         stroke-linecap="round"
@@ -489,7 +490,7 @@ const fieldToInputType: { [key: string]: string } = {
                                                     viewBox="0 0 24 24"
                                                     stroke-width="1.5"
                                                     stroke="currentColor"
-                                                    class="w-6 h-6"
+                                                    class="w-20"
                                                 >
                                                     <path
                                                         stroke-linecap="round"

--- a/src/components/helpers/list.vue
+++ b/src/components/helpers/list.vue
@@ -179,7 +179,7 @@ const fieldToInputType: { [key: string]: string } = {
                     'cursor-not-allowed bg-gray-500': props.editDisabled,
                     'bg-black cursor-pointer hover:bg-gray-800': !props.editDisabled
                 }"
-                class="ml-auto p-1 text-white flex-shrink-0 flex items-center justify-center"
+                class="ml-auto p-4 text-white flex-shrink-0 flex items-center justify-center"
             >
                 <svg
                     class="relative bottom-[2px]"

--- a/src/components/helpers/list.vue
+++ b/src/components/helpers/list.vue
@@ -161,7 +161,7 @@ const fieldToInputType: { [key: string]: string } = {
 <template>
     <Collapsible :thick-border="topLevel">
         <template #header>
-            <button :content="t('editor.expand')" v-tippy class="arrow mr-1 sm:mr-3" :aria-label="t('editor.expand')">
+            <button :content="t('editor.expand')" v-tippy class="arrow mr-1 ce-sm:mr-3" :aria-label="t('editor.expand')">
                 <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="20">
                     <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
                 </svg>
@@ -381,7 +381,7 @@ const fieldToInputType: { [key: string]: string } = {
                                     <button
                                         :disabled="editDisabled"
                                         :class="{ handle: !editDisabled }"
-                                        class="cursor-move disabled:text-gray-500 disabled:cursor-not-allowed mr-1 sm:mr-3"
+                                        class="cursor-move disabled:text-gray-500 disabled:cursor-not-allowed mr-1 ce-sm:mr-3"
                                         @click.stop
                                         :content="t('editor.reorder')"
                                         v-tippy
@@ -405,7 +405,7 @@ const fieldToInputType: { [key: string]: string } = {
                                     <button
                                         :content="t('editor.expand')"
                                         v-tippy
-                                        class="mr-1 sm:mr-3 arrow"
+                                        class="mr-1 ce-sm:mr-3 arrow"
                                         :aria-label="t('editor.expand')"
                                     >
                                         <svg
@@ -417,7 +417,7 @@ const fieldToInputType: { [key: string]: string } = {
                                             <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
                                         </svg>
                                     </button>
-                                    <span class="mr-1 sm:mr-5 sm:text-lg">{{
+                                    <span class="mr-1 ce-sm:mr-5 ce-sm:text-lg">{{
                                         list[index].id ||
                                         list[index].name ||
                                         list[index].layerId ||

--- a/src/components/helpers/select.vue
+++ b/src/components/helpers/select.vue
@@ -22,7 +22,7 @@ defineProps({
 <template>
     <div>
         <InputHeader :required="required" :class="headerClass" :title="title" :description="description" />
-        <select :aria-label="title" v-model="model" :disabled="disabled ?? false">
+        <select :aria-label="title" v-model="model" class="block border border-black text-sm" :disabled="disabled ?? false">
             <option v-for="(opt, idx) in options" :value="opt.value" :key="idx">{{ opt.label }}</option>
         </select>
     </div>

--- a/src/components/layers/layers.vue
+++ b/src/components/layers/layers.vue
@@ -1,3 +1,441 @@
+<template>
+    <div>
+        <!-- Header -->
+        <div class="flex items-center">
+            <h3 class="text-2xl font-semibold">{{ t('layers.title') }} ({{ store.elc.layers.length }})</h3>
+            <div class="flex ml-auto">
+                <button
+                    class="bg-black hover:bg-gray-800 p-4 text-white flex-shrink-0 flex items-center justify-center"
+                    :class="updatedLegend ? 'cursor-default' : 'cursor-pointer'"
+                    @click="updateLegend"
+                    :aria-label="updatedLegend ? t('layers.updatedLegend.title') : t('layers.autopopulateLegend.title')"
+                >
+                    <svg
+                        v-if="updatedLegend"
+                        data-slot="icon"
+                        fill="none"
+                        stroke-width="1.5"
+                        width="20px"
+                        height="20px"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                        aria-hidden="true"
+                    >
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"></path>
+                    </svg>
+                    <svg
+                        v-else
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="white"
+                        height="20px"
+                        width="20px"
+                    >
+                        <path d="M0 0h24v24H0z" fill="none" />
+                        <path
+                            d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"
+                        />
+                    </svg>
+                    <span class="px-8">
+                        {{ updatedLegend ? t('layers.updatedLegend.title') : t('layers.autopopulateLegend.title') }}
+                    </span>
+                    <button
+                        class="relative bottom-[1.5px]"
+                        v-if="!updatedLegend && (!allHaveId || !allUniqueIds)"
+                        :content="t('layers.idWarning')"
+                        v-tippy="{
+                            placement: 'top',
+                            trigger: 'mouseenter manual focus click'
+                        }"
+                        @click.stop
+                    >
+                        ⚠
+                    </button>
+                    <button
+                        v-if="!updatedLegend"
+                        :content="t('layers.autopopulateLegend.description')"
+                        :aria-label="t('layers.autopopulateLegend.description')"
+                        v-tippy="{
+                            placement: 'top',
+                            trigger: 'mouseenter manual focus click'
+                        }"
+                        @click.stop
+                    >
+                        <svg class="fill-current w-16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                            />
+                        </svg>
+                    </button>
+                </button>
+                <!-- add item button -->
+                <button
+                    class="bg-black cursor-pointer hover:bg-gray-800 ml-8 p-4 text-white flex-shrink-0 flex items-center justify-center"
+                    @click="addLayer"
+                >
+                    <svg
+                        class="relative bottom-[2px]"
+                        fill="white"
+                        height="18px"
+                        width="18px"
+                        viewBox="0 0 23 21"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                    </svg>
+                    <span class="px-2"> {{ t('layers.add') }} </span>
+                </button>
+            </div>
+        </div>
+        <!-- List of Layer Configs -->
+        <div>
+            <draggable
+                v-if="store.elc.layers.length > 0"
+                :list="store.elc.layers"
+                item-key="fake"
+                handle=".handle"
+                @change="onMoveEnd"
+            >
+                <template #item="{ element, index }">
+                    <Collapsible :thick-border="true">
+                        <template #header>
+                            <button
+                                :content="t('editor.reorder')"
+                                v-tippy
+                                class="cursor-move handle mr-1 ce-sm:mr-5"
+                                @click.stop
+                                :aria-label="t('editor.reorder')"
+                            >
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke-width="1.5"
+                                    stroke="currentColor"
+                                    class="w-20"
+                                >
+                                    <path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        d="M3.75 5.25h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5"
+                                    />
+                                </svg>
+                            </button>
+                            <button
+                                :content="t('editor.expand')"
+                                v-tippy
+                                class="arrow mr-4 ce-sm:mr-20"
+                                :aria-label="t('editor.expand')"
+                            >
+                                <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="20">
+                                    <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+                                </svg>
+                            </button>
+                            <span class="mr-4 ce-sm:mr-20 ce-sm:text-lg">{{
+                                element.id ? element.id : t('layer.title', [index + 1])
+                            }}</span>
+                            <div class="flex ml-auto">
+                                <button
+                                    @click.stop="removeLayer(index)"
+                                    class="mr-4"
+                                    :aria-label="t('layers.remove')"
+                                    :content="t('layers.remove')"
+                                    v-tippy
+                                >
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                        stroke-width="1.5"
+                                        stroke="currentColor"
+                                        class="w-20"
+                                    >
+                                        <path
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                        />
+                                    </svg>
+                                </button>
+                                <div class="flex flex-col">
+                                    <button
+                                        @click.stop="reorderLayer(index, -1)"
+                                        :disabled="index === 0"
+                                        class="disabled:text-gray-500 disabled:cursor-not-allowed"
+                                        :aria-label="t('editor.up')"
+                                        :content="t('editor.up')"
+                                        v-tippy
+                                    >
+                                        <svg
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                            stroke-width="1.5"
+                                            stroke="currentColor"
+                                            class="w-20"
+                                        >
+                                            <path
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                d="m4.5 15.75 7.5-7.5 7.5 7.5"
+                                            />
+                                        </svg>
+                                    </button>
+                                    <button
+                                        @click.stop="reorderLayer(index, 1)"
+                                        :disabled="index === store.elc.layers.length - 1"
+                                        class="disabled:text-gray-500 disabled:cursor-not-allowed"
+                                        :aria-label="t('editor.down')"
+                                        :content="t('editor.down')"
+                                        v-tippy
+                                    >
+                                        <svg
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                            stroke-width="1.5"
+                                            stroke="currentColor"
+                                            class="w-20"
+                                        >
+                                            <path
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                d="m19.5 8.25-7.5 7.5-7.5-7.5"
+                                            />
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </template>
+                        <template #default>
+                            <div class="input-table mt-20">
+                                <GroupSelect
+                                    :title="t('layer.type')"
+                                    required
+                                    v-model="element.layerType"
+                                    :options="[
+                                        {
+                                            groupLabel: t('layer.type.group.esri'),
+                                            groupOptions: [
+                                                { label: t('layer.type.feature'), value: LayerType.FEATURE },
+                                                { label: t('layer.type.mapImage'), value: LayerType.MAPIMAGE },
+                                                { label: t('layer.type.tile'), value: LayerType.TILE },
+                                                { label: t('layer.type.imagery'), value: LayerType.IMAGERY }
+                                            ]
+                                        },
+                                        {
+                                            groupLabel: t('layer.type.group.ogc'),
+                                            groupOptions: [
+                                                { label: t('layer.type.wfs'), value: LayerType.WFS },
+                                                { label: t('layer.type.wms'), value: LayerType.WMS }
+                                            ]
+                                        },
+                                        {
+                                            groupLabel: t('layer.type.group.file'),
+                                            groupOptions: [
+                                                { label: t('layer.type.csv'), value: LayerType.CSV },
+                                                { label: t('layer.type.geojson'), value: LayerType.GEOJSON },
+                                                { label: t('layer.type.geojsonzip'), value: LayerType.GEOJSONZIPPED },
+                                                { label: t('layer.type.shapefile'), value: LayerType.SHAPEFILE },
+                                                { label: t('layer.type.flatty'), value: LayerType.FLATGEOBUF },
+                                                { label: t('layer.type.flattyzip'), value: LayerType.FLATGEOBUFZIPPED }
+                                            ]
+                                        },
+                                        {
+                                            groupLabel: t('layer.type.group.data'),
+                                            groupOptions: [
+                                                { label: t('layer.type.datatable'), value: LayerType.DATATABLE },
+                                                { label: t('layer.type.datacsv'), value: LayerType.DATACSV },
+                                                { label: t('layer.type.datajson'), value: LayerType.DATAJSON }
+                                            ]
+                                        }
+                                    ]"
+                                />
+                                <Input
+                                    :title="t('layer.id.title')"
+                                    :description="t('layer.id.description')"
+                                    :model-value="element.id"
+                                    @update:model-value="id => onLayerIdChange(id, index)"
+                                    required
+                                />
+                                <Input
+                                    :title="t('layer.name.title')"
+                                    :description="t('layer.name.description')"
+                                    v-model="element.name"
+                                />
+                                <Input
+                                    :title="t('layer.url.title')"
+                                    :description="t('layer.url.description')"
+                                    v-model="element.url"
+                                    required
+                                />
+                                <Input
+                                    v-if="LayerTools.isAttributeLayer(element)"
+                                    :title="t('layer.nameField.title')"
+                                    :description="t('layer.nameField.description')"
+                                    v-model="element.nameField"
+                                />
+                                <Input
+                                    v-if="LayerTools.isVectorLayer(element)"
+                                    :title="t('layer.maptipField.title')"
+                                    :description="t('layer.maptipField.description')"
+                                    v-model="element.maptipField"
+                                />
+                                <Input
+                                    :title="t('layer.expectedDrawTime.title')"
+                                    :description="t('layer.expectedDrawTime.description')"
+                                    v-model="element.expectedDrawTime"
+                                    type="number"
+                                    min="0"
+                                />
+                                <Input
+                                    :title="t('layer.expectedLoadTime.title')"
+                                    :description="t('layer.expectedLoadTime.description')"
+                                    v-model="element.expectedLoadTime"
+                                    type="number"
+                                    min="0"
+                                />
+                                <Input
+                                    :title="t('layer.maxLoadTime.title')"
+                                    :description="t('layer.maxLoadTime.description')"
+                                    v-model="element.maxLoadTime"
+                                    type="number"
+                                    min="0"
+                                    placeholder="0"
+                                />
+                                <Input
+                                    v-if="LayerTools.isFileLayer(element)"
+                                    :title="t('layer.colour.title')"
+                                    :description="t('layer.colour.description')"
+                                    v-model="element.colour"
+                                />
+                                <Input
+                                    v-if="LayerTools.isCSV(element)"
+                                    :title="t('layer.latField.title')"
+                                    :description="t('layer.latField.description')"
+                                    v-model="element.latField"
+                                />
+                                <Input
+                                    v-if="LayerTools.isCSV(element)"
+                                    :title="t('layer.longField.title')"
+                                    :description="t('layer.longField.description')"
+                                    v-model="element.longField"
+                                />
+                                <Input
+                                    v-if="LayerTools.isToleranceLayer(element)"
+                                    :title="t('layer.mouseTolerance.title')"
+                                    :description="t('layer.mouseTolerance.description')"
+                                    v-model="element.mouseTolerance"
+                                    type="number"
+                                    min="0"
+                                    placeholder="5"
+                                />
+                                <Input
+                                    v-if="LayerTools.isToleranceLayer(element)"
+                                    :title="t('layer.touchTolerance.title')"
+                                    :description="t('layer.touchTolerance.description')"
+                                    v-model="element.touchTolerance"
+                                    type="number"
+                                    min="0"
+                                    placeholder="15"
+                                />
+                                <Input
+                                    v-if="LayerTools.isAttributeLayer(element)"
+                                    :title="t('layer.initialFilteredQuery.title')"
+                                    :description="t('layer.initialFilteredQuery.description')"
+                                    v-model="element.initialFilteredQuery"
+                                />
+                                <Input
+                                    v-if="LayerTools.isAttributeLayer(element)"
+                                    :title="t('layer.permanentFilteredQuery.title')"
+                                    :description="t('layer.permanentFilteredQuery.description')"
+                                    v-model="element.permanentFilteredQuery"
+                                />
+                                <Select
+                                    v-if="LayerTools.isVectorLayer(element)"
+                                    :title="t('layer.identifyMode.title')"
+                                    :description="t('layer.identifyMode.description')"
+                                    v-model="element.identifyMode"
+                                    :options="[
+                                        {
+                                            label: t('layer.identifyMode.geometric'),
+                                            value: LayerIdentifyMode.GEOMETRIC
+                                        },
+                                        { label: t('layer.identifyMode.symbolic'), value: LayerIdentifyMode.SYMBOLIC },
+                                        { label: t('layer.identifyMode.hybrid'), value: LayerIdentifyMode.HYBRID }
+                                    ]"
+                                />
+                                <Select
+                                    v-if="LayerTools.isMIL(element)"
+                                    :title="t('layer.imageFormat.title')"
+                                    :description="t('layer.imageFormat.description')"
+                                    v-model="element.imageFormat"
+                                    :options="
+                                        imgFormatOpts.map(format => {
+                                            return { label: format, value: format };
+                                        })
+                                    "
+                                />
+                                <Input
+                                    v-if="LayerTools.isVectorLayer(element)"
+                                    type="object"
+                                    :title="t('layer.customRenderer.title')"
+                                    :description="t('layer.customRenderer.description')"
+                                    v-model="element.customRenderer"
+                                />
+                                <Input
+                                    v-if="LayerTools.isGeoJson(element) || LayerTools.isCSV(element)"
+                                    :type="LayerTools.isGeoJson(element) ? 'object' : 'text'"
+                                    :title="t('layer.rawData.title')"
+                                    :description="
+                                        t(
+                                            `layer.rawData.${
+                                                LayerTools.isGeoJson(element) ? 'geojson' : 'csv'
+                                            }.description`
+                                        )
+                                    "
+                                    v-model="element.rawData"
+                                />
+                            </div>
+                            <Checkbox
+                                v-if="LayerTools.isWFS(element)"
+                                :title="t('layer.xyInAttribs.title')"
+                                :description="t('layer.xyInAttribs.description')"
+                                v-model="element.xyInAttribs"
+                            />
+                            <Checkbox
+                                v-if="LayerTools.isFileLayer(element)"
+                                :title="t('layer.caching.title')"
+                                :description="t('layer.caching.description')"
+                                v-model="element.caching"
+                            />
+
+                            <Sublayers
+                                v-if="LayerTools.isParentLayer(element)"
+                                v-model="element.sublayers"
+                                :layer-type="element.layerType"
+                            />
+                            <Metadata v-model="element.metadata" />
+                            <Extent v-model="element.extent" :title="t('layer.extent')" />
+                            <Controls v-model="element.controls" />
+                            <Controls v-model="element.disabledControls" disabled />
+                            <State v-model="element.state" />
+                            <FieldMetadata
+                                v-model="element.fieldMetadata"
+                                v-if="LayerTools.isAttributeLayer(element)"
+                            />
+                            <DrawOrder v-model="element.drawOrder" v-if="LayerTools.isVectorLayer(element)" />
+                            <Fixtures v-model="element.fixtures" :layer-type="element.layerType" :sublayer="false" />
+                        </template>
+                    </Collapsible>
+                </template>
+            </draggable>
+        </div>
+    </div>
+</template>
+
 <script setup lang="ts">
 // root.layers config nugget
 
@@ -231,441 +669,3 @@ const rubbishRemover = (config: RampLayerConfig, oldLayerType: LayerType, newLay
     }
 };
 </script>
-
-<template>
-    <div>
-        <!-- Header -->
-        <div class="flex items-center">
-            <h1 class="text-2xl font-semibold">{{ t('layers.title') }} ({{ store.elc.layers.length }})</h1>
-            <div class="flex ml-auto">
-                <button
-                    class="bg-black hover:bg-gray-800 p-1 text-white flex-shrink-0 flex items-center justify-center"
-                    :class="updatedLegend ? 'cursor-default' : 'cursor-pointer'"
-                    @click="updateLegend"
-                    :aria-label="updatedLegend ? t('layers.updatedLegend.title') : t('layers.autopopulateLegend.title')"
-                >
-                    <svg
-                        v-if="updatedLegend"
-                        data-slot="icon"
-                        fill="none"
-                        stroke-width="1.5"
-                        width="20px"
-                        height="20px"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                        aria-hidden="true"
-                    >
-                        <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"></path>
-                    </svg>
-                    <svg
-                        v-else
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="white"
-                        height="20px"
-                        width="20px"
-                    >
-                        <path d="M0 0h24v24H0z" fill="none" />
-                        <path
-                            d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"
-                        />
-                    </svg>
-                    <span class="px-2">
-                        {{ updatedLegend ? t('layers.updatedLegend.title') : t('layers.autopopulateLegend.title') }}
-                    </span>
-                    <button
-                        class="relative bottom-[1.5px]"
-                        v-if="!updatedLegend && (!allHaveId || !allUniqueIds)"
-                        :content="t('layers.idWarning')"
-                        v-tippy="{
-                            placement: 'top',
-                            trigger: 'mouseenter manual focus click'
-                        }"
-                        @click.stop
-                    >
-                        ⚠
-                    </button>
-                    <button
-                        v-if="!updatedLegend"
-                        :content="t('layers.autopopulateLegend.description')"
-                        :aria-label="t('layers.autopopulateLegend.description')"
-                        v-tippy="{
-                            placement: 'top',
-                            trigger: 'mouseenter manual focus click'
-                        }"
-                        @click.stop
-                    >
-                        <svg class="fill-current w-20 h-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path
-                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-                            />
-                        </svg>
-                    </button>
-                </button>
-                <!-- add item button -->
-                <button
-                    class="bg-black cursor-pointer hover:bg-gray-800 ml-8 p-4 text-white flex-shrink-0 flex items-center justify-center"
-                    @click="addLayer"
-                >
-                    <svg
-                        class="relative bottom-[2px]"
-                        fill="white"
-                        height="18px"
-                        width="18px"
-                        viewBox="0 0 23 21"
-                        xmlns="http://www.w3.org/2000/svg"
-                    >
-                        <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
-                    </svg>
-                    <span class="px-2"> {{ t('layers.add') }} </span>
-                </button>
-            </div>
-        </div>
-        <!-- List of Layer Configs -->
-        <div>
-            <draggable
-                v-if="store.elc.layers.length > 0"
-                :list="store.elc.layers"
-                item-key="fake"
-                handle=".handle"
-                @change="onMoveEnd"
-            >
-                <template #item="{ element, index }">
-                    <Collapsible :thick-border="true">
-                        <template #header>
-                            <button
-                                :content="t('editor.reorder')"
-                                v-tippy
-                                class="cursor-move handle mr-1 ce-sm:mr-5"
-                                @click.stop
-                                :aria-label="t('editor.reorder')"
-                            >
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke-width="1.5"
-                                    stroke="currentColor"
-                                    class="w-6 h-6"
-                                >
-                                    <path
-                                        stroke-linecap="round"
-                                        stroke-linejoin="round"
-                                        d="M3.75 5.25h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5"
-                                    />
-                                </svg>
-                            </button>
-                            <button
-                                :content="t('editor.expand')"
-                                v-tippy
-                                class="arrow mr-1 ce-sm:mr-5"
-                                :aria-label="t('editor.expand')"
-                            >
-                                <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="20">
-                                    <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
-                                </svg>
-                            </button>
-                            <span class="mr-1 ce-sm:mr-5 ce-sm:text-lg">{{
-                                element.id ? element.id : t('layer.title', [index + 1])
-                            }}</span>
-                            <div class="flex ml-auto">
-                                <button
-                                    @click.stop="removeLayer(index)"
-                                    class="mr-1"
-                                    :aria-label="t('layers.remove')"
-                                    :content="t('layers.remove')"
-                                    v-tippy
-                                >
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        fill="none"
-                                        viewBox="0 0 24 24"
-                                        stroke-width="1.5"
-                                        stroke="currentColor"
-                                        class="w-6 h-6"
-                                    >
-                                        <path
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                                        />
-                                    </svg>
-                                </button>
-                                <div class="flex flex-col">
-                                    <button
-                                        @click.stop="reorderLayer(index, -1)"
-                                        :disabled="index === 0"
-                                        class="disabled:text-gray-500 disabled:cursor-not-allowed"
-                                        :aria-label="t('editor.up')"
-                                        :content="t('editor.up')"
-                                        v-tippy
-                                    >
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            fill="none"
-                                            viewBox="0 0 24 24"
-                                            stroke-width="1.5"
-                                            stroke="currentColor"
-                                            class="w-6 h-6"
-                                        >
-                                            <path
-                                                stroke-linecap="round"
-                                                stroke-linejoin="round"
-                                                d="m4.5 15.75 7.5-7.5 7.5 7.5"
-                                            />
-                                        </svg>
-                                    </button>
-                                    <button
-                                        @click.stop="reorderLayer(index, 1)"
-                                        :disabled="index === store.elc.layers.length - 1"
-                                        class="disabled:text-gray-500 disabled:cursor-not-allowed"
-                                        :aria-label="t('editor.down')"
-                                        :content="t('editor.down')"
-                                        v-tippy
-                                    >
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            fill="none"
-                                            viewBox="0 0 24 24"
-                                            stroke-width="1.5"
-                                            stroke="currentColor"
-                                            class="w-6 h-6"
-                                        >
-                                            <path
-                                                stroke-linecap="round"
-                                                stroke-linejoin="round"
-                                                d="m19.5 8.25-7.5 7.5-7.5-7.5"
-                                            />
-                                        </svg>
-                                    </button>
-                                </div>
-                            </div>
-                        </template>
-                        <template #default>
-                            <div class="input-table mt-5">
-                                <GroupSelect
-                                    :title="t('layer.type')"
-                                    required
-                                    v-model="element.layerType"
-                                    :options="[
-                                        {
-                                            groupLabel: t('layer.type.group.esri'),
-                                            groupOptions: [
-                                                { label: t('layer.type.feature'), value: LayerType.FEATURE },
-                                                { label: t('layer.type.mapImage'), value: LayerType.MAPIMAGE },
-                                                { label: t('layer.type.tile'), value: LayerType.TILE },
-                                                { label: t('layer.type.imagery'), value: LayerType.IMAGERY }
-                                            ]
-                                        },
-                                        {
-                                            groupLabel: t('layer.type.group.ogc'),
-                                            groupOptions: [
-                                                { label: t('layer.type.wfs'), value: LayerType.WFS },
-                                                { label: t('layer.type.wms'), value: LayerType.WMS }
-                                            ]
-                                        },
-                                        {
-                                            groupLabel: t('layer.type.group.file'),
-                                            groupOptions: [
-                                                { label: t('layer.type.csv'), value: LayerType.CSV },
-                                                { label: t('layer.type.geojson'), value: LayerType.GEOJSON },
-                                                { label: t('layer.type.geojsonzip'), value: LayerType.GEOJSONZIPPED },
-                                                { label: t('layer.type.shapefile'), value: LayerType.SHAPEFILE },
-                                                { label: t('layer.type.flatty'), value: LayerType.FLATGEOBUF },
-                                                { label: t('layer.type.flattyzip'), value: LayerType.FLATGEOBUFZIPPED }
-                                            ]
-                                        },
-                                        {
-                                            groupLabel: t('layer.type.group.data'),
-                                            groupOptions: [
-                                                { label: t('layer.type.datatable'), value: LayerType.DATATABLE },
-                                                { label: t('layer.type.datacsv'), value: LayerType.DATACSV },
-                                                { label: t('layer.type.datajson'), value: LayerType.DATAJSON }
-                                            ]
-                                        }
-                                    ]"
-                                />
-                                <Input
-                                    :title="t('layer.id.title')"
-                                    :description="t('layer.id.description')"
-                                    :model-value="element.id"
-                                    @update:model-value="id => onLayerIdChange(id, index)"
-                                    required
-                                />
-                                <Input
-                                    :title="t('layer.name.title')"
-                                    :description="t('layer.name.description')"
-                                    v-model="element.name"
-                                />
-                                <Input
-                                    :title="t('layer.url.title')"
-                                    :description="t('layer.url.description')"
-                                    v-model="element.url"
-                                    required
-                                />
-                                <Input
-                                    v-if="LayerTools.isAttributeLayer(element)"
-                                    :title="t('layer.nameField.title')"
-                                    :description="t('layer.nameField.description')"
-                                    v-model="element.nameField"
-                                />
-                                <Input
-                                    v-if="LayerTools.isVectorLayer(element)"
-                                    :title="t('layer.maptipField.title')"
-                                    :description="t('layer.maptipField.description')"
-                                    v-model="element.maptipField"
-                                />
-                                <Input
-                                    :title="t('layer.expectedDrawTime.title')"
-                                    :description="t('layer.expectedDrawTime.description')"
-                                    v-model="element.expectedDrawTime"
-                                    type="number"
-                                    min="0"
-                                />
-                                <Input
-                                    :title="t('layer.expectedLoadTime.title')"
-                                    :description="t('layer.expectedLoadTime.description')"
-                                    v-model="element.expectedLoadTime"
-                                    type="number"
-                                    min="0"
-                                />
-                                <Input
-                                    :title="t('layer.maxLoadTime.title')"
-                                    :description="t('layer.maxLoadTime.description')"
-                                    v-model="element.maxLoadTime"
-                                    type="number"
-                                    min="0"
-                                    placeholder="0"
-                                />
-                                <Input
-                                    v-if="LayerTools.isFileLayer(element)"
-                                    :title="t('layer.colour.title')"
-                                    :description="t('layer.colour.description')"
-                                    v-model="element.colour"
-                                />
-                                <Input
-                                    v-if="LayerTools.isCSV(element)"
-                                    :title="t('layer.latField.title')"
-                                    :description="t('layer.latField.description')"
-                                    v-model="element.latField"
-                                />
-                                <Input
-                                    v-if="LayerTools.isCSV(element)"
-                                    :title="t('layer.longField.title')"
-                                    :description="t('layer.longField.description')"
-                                    v-model="element.longField"
-                                />
-                                <Input
-                                    v-if="LayerTools.isToleranceLayer(element)"
-                                    :title="t('layer.mouseTolerance.title')"
-                                    :description="t('layer.mouseTolerance.description')"
-                                    v-model="element.mouseTolerance"
-                                    type="number"
-                                    min="0"
-                                    placeholder="5"
-                                />
-                                <Input
-                                    v-if="LayerTools.isToleranceLayer(element)"
-                                    :title="t('layer.touchTolerance.title')"
-                                    :description="t('layer.touchTolerance.description')"
-                                    v-model="element.touchTolerance"
-                                    type="number"
-                                    min="0"
-                                    placeholder="15"
-                                />
-                                <Input
-                                    v-if="LayerTools.isAttributeLayer(element)"
-                                    :title="t('layer.initialFilteredQuery.title')"
-                                    :description="t('layer.initialFilteredQuery.description')"
-                                    v-model="element.initialFilteredQuery"
-                                />
-                                <Input
-                                    v-if="LayerTools.isAttributeLayer(element)"
-                                    :title="t('layer.permanentFilteredQuery.title')"
-                                    :description="t('layer.permanentFilteredQuery.description')"
-                                    v-model="element.permanentFilteredQuery"
-                                />
-                                <Select
-                                    v-if="LayerTools.isVectorLayer(element)"
-                                    :title="t('layer.identifyMode.title')"
-                                    :description="t('layer.identifyMode.description')"
-                                    v-model="element.identifyMode"
-                                    :options="[
-                                        {
-                                            label: t('layer.identifyMode.geometric'),
-                                            value: LayerIdentifyMode.GEOMETRIC
-                                        },
-                                        { label: t('layer.identifyMode.symbolic'), value: LayerIdentifyMode.SYMBOLIC },
-                                        { label: t('layer.identifyMode.hybrid'), value: LayerIdentifyMode.HYBRID }
-                                    ]"
-                                />
-                                <Select
-                                    v-if="LayerTools.isMIL(element)"
-                                    :title="t('layer.imageFormat.title')"
-                                    :description="t('layer.imageFormat.description')"
-                                    v-model="element.imageFormat"
-                                    :options="
-                                        imgFormatOpts.map(format => {
-                                            return { label: format, value: format };
-                                        })
-                                    "
-                                />
-                                <Input
-                                    v-if="LayerTools.isVectorLayer(element)"
-                                    type="object"
-                                    :title="t('layer.customRenderer.title')"
-                                    :description="t('layer.customRenderer.description')"
-                                    v-model="element.customRenderer"
-                                />
-                                <Input
-                                    v-if="LayerTools.isGeoJson(element) || LayerTools.isCSV(element)"
-                                    :type="LayerTools.isGeoJson(element) ? 'object' : 'text'"
-                                    :title="t('layer.rawData.title')"
-                                    :description="
-                                        t(
-                                            `layer.rawData.${
-                                                LayerTools.isGeoJson(element) ? 'geojson' : 'csv'
-                                            }.description`
-                                        )
-                                    "
-                                    v-model="element.rawData"
-                                />
-                            </div>
-                            <Checkbox
-                                v-if="LayerTools.isWFS(element)"
-                                :title="t('layer.xyInAttribs.title')"
-                                :description="t('layer.xyInAttribs.description')"
-                                v-model="element.xyInAttribs"
-                            />
-                            <Checkbox
-                                v-if="LayerTools.isFileLayer(element)"
-                                :title="t('layer.caching.title')"
-                                :description="t('layer.caching.description')"
-                                v-model="element.caching"
-                            />
-
-                            <Sublayers
-                                v-if="LayerTools.isParentLayer(element)"
-                                v-model="element.sublayers"
-                                :layer-type="element.layerType"
-                            />
-                            <Metadata v-model="element.metadata" />
-                            <Extent v-model="element.extent" :title="t('layer.extent')" />
-                            <Controls v-model="element.controls" />
-                            <Controls v-model="element.disabledControls" disabled />
-                            <State v-model="element.state" />
-                            <FieldMetadata
-                                v-model="element.fieldMetadata"
-                                v-if="LayerTools.isAttributeLayer(element)"
-                            />
-                            <DrawOrder v-model="element.drawOrder" v-if="LayerTools.isVectorLayer(element)" />
-                            <Fixtures v-model="element.fixtures" :layer-type="element.layerType" :sublayer="false" />
-                        </template>
-                    </Collapsible>
-                </template>
-            </draggable>
-        </div>
-    </div>
-</template>

--- a/src/components/layers/layers.vue
+++ b/src/components/layers/layers.vue
@@ -296,7 +296,7 @@ const rubbishRemover = (config: RampLayerConfig, oldLayerType: LayerType, newLay
                         }"
                         @click.stop
                     >
-                        <svg class="fill-current w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <svg class="fill-current w-20 h-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                             <path d="M0 0h24v24H0z" fill="none"></path>
                             <path
                                 d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
@@ -306,7 +306,7 @@ const rubbishRemover = (config: RampLayerConfig, oldLayerType: LayerType, newLay
                 </button>
                 <!-- add item button -->
                 <button
-                    class="bg-black cursor-pointer hover:bg-gray-800 ml-2 p-1 text-white flex-shrink-0 flex items-center justify-center"
+                    class="bg-black cursor-pointer hover:bg-gray-800 ml-8 p-4 text-white flex-shrink-0 flex items-center justify-center"
                     @click="addLayer"
                 >
                     <svg
@@ -338,7 +338,7 @@ const rubbishRemover = (config: RampLayerConfig, oldLayerType: LayerType, newLay
                             <button
                                 :content="t('editor.reorder')"
                                 v-tippy
-                                class="cursor-move handle mr-1 sm:mr-5"
+                                class="cursor-move handle mr-1 ce-sm:mr-5"
                                 @click.stop
                                 :aria-label="t('editor.reorder')"
                             >
@@ -360,14 +360,14 @@ const rubbishRemover = (config: RampLayerConfig, oldLayerType: LayerType, newLay
                             <button
                                 :content="t('editor.expand')"
                                 v-tippy
-                                class="arrow mr-1 sm:mr-5"
+                                class="arrow mr-1 ce-sm:mr-5"
                                 :aria-label="t('editor.expand')"
                             >
                                 <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="20">
                                     <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
                                 </svg>
                             </button>
-                            <span class="mr-1 sm:mr-5 sm:text-lg">{{
+                            <span class="mr-1 ce-sm:mr-5 ce-sm:text-lg">{{
                                 element.id ? element.id : t('layer.title', [index + 1])
                             }}</span>
                             <div class="flex ml-auto">

--- a/src/components/map/caption.vue
+++ b/src/components/map/caption.vue
@@ -45,7 +45,7 @@ const onInput = (section: 'mapCoords' | 'scaleBar' | 'langToggle', key: string, 
 <template>
     <Collapsible :title="t('caption.title')" :description="t('caption.description')" :thick-border="true">
         <Collapsible :title="t('caption.coords.title')" :description="t('caption.coords.description')" required>
-            <div class="input-table">
+            <div>
                 <Select
                     :title="t('caption.coords.formatter.title')"
                     :description="t('caption.coords.formatter.description')"

--- a/src/components/map/lod-sets.vue
+++ b/src/components/map/lod-sets.vue
@@ -118,6 +118,14 @@ const lodFields: Array<Field> = [
 
 <style lang="scss" scoped>
 .use-default {
-    @apply bg-black text-white p-2 hover:bg-gray-800 rounded-md;
+    @apply bg-black text-white p-4 rounded-[4px];
+        outline: none;
+        border-width: 1px;
+        border-color: #000;
+        &:hover,
+        &:focus {
+            background-color: rgba(209, 213, 219, 1);
+            color: black;
+        }
 }
 </style>

--- a/src/components/map/map.vue
+++ b/src/components/map/map.vue
@@ -18,7 +18,7 @@ const { t } = useI18n();
 
 <template>
     <div>
-        <h1 class="text-2xl font-semibold">Map</h1>
+        <h3 class="text-2xl font-semibold">Map</h3>
         <div class="mt-4 input-table">
             <Input
                 :title="t('map.initialBasemapId.title')"

--- a/src/components/navbar.vue
+++ b/src/components/navbar.vue
@@ -2,7 +2,7 @@
 <template>
     <div class="navbar-wrapper flex flex-col items-center border-black border-2 divide-y divide-slate-200">
         <div
-            class="w-full p-1 sm:p-3 hover:bg-gray-200 cursor-pointer border-gray-800"
+            class="w-full p-4 ce-sm:px-12 hover:bg-gray-200 cursor-pointer border-gray-800"
             :class="{ 'bg-gray-200': store.editingTemplate === 'starting-fixtures' }"
             @click="setTemplate('starting-fixtures')"
         >
@@ -10,7 +10,7 @@
         </div>
         <div class="w-full">
             <div
-                class="flex items-center hover:bg-gray-200 cursor-pointer w-full p-1 sm:p-3"
+                class="flex items-center hover:bg-gray-200 cursor-pointer w-full p-4 ce-sm:px-12"
                 @click="
                     () => {
                         configsExpanded = !configsExpanded;
@@ -18,7 +18,7 @@
                 "
             >
                 <svg
-                    class="sm:mr-1"
+                    class="ce-sm:mr-4"
                     xmlns="http://www.w3.org/2000/svg"
                     height="18"
                     viewBox="0 0 24 24"
@@ -30,7 +30,7 @@
                 {{ t('navbar.configs') }}
             </div>
             <template v-if="configsExpanded">
-                <div v-for="lang in Object.keys(store.configs)" :key="`config-${lang}`" class="ml-2 sm:ml-5">
+                <div v-for="lang in Object.keys(store.configs)" :key="`config-${lang}`" class="ml-8 ce-sm:ml-20">
                     <div
                         class="flex items-center hover:bg-gray-200 cursor-pointer"
                         @click="
@@ -40,7 +40,7 @@
                         "
                     >
                         <svg
-                            class="sm:mr-1"
+                            class="ce-sm:mr-4"
                             xmlns="http://www.w3.org/2000/svg"
                             height="18"
                             viewBox="0 0 24 24"
@@ -55,7 +55,7 @@
                         <div
                             v-for="section in sections"
                             :key="`${section}-${lang}`"
-                            class="hover:bg-gray-200 cursor-pointer ml-1 sm:ml-3 pl-1 sm:pl-2"
+                            class="hover:bg-gray-200 cursor-pointer ml-4 ce-sm:ml-12 pl-4 ce-sm:pl-8"
                             :class="{
                                 'bg-gray-200':
                                     store.editingTemplate === section.toLowerCase() && store.editingLang === lang
@@ -69,7 +69,7 @@
             </template>
         </div>
         <div
-            class="hover:bg-gray-200 cursor-pointer w-full p-1 sm:p-3"
+            class="hover:bg-gray-200 cursor-pointer w-full p-4 ce-sm:px-12"
             :class="{ 'bg-gray-200': store.editingTemplate === 'options' }"
             @click="setTemplate('options')"
         >
@@ -77,15 +77,15 @@
         </div>
         <span class="mt-auto"></span>
         <div class="w-full flex-col justify-items-center">
-            <div class="w-full flex justify-center sm:w-4/5">
+            <div class="w-full flex justify-center ce-sm:w-4/5">
                 <button
-                    class="black-bg-button"
+                    class="white-bg-button"
                     @click="setTemplate('preview')"
                 >
                     {{ t('navbar.preview') }}
                 </button>
             </div>
-            <div v-if="!props.library" class="w-full flex justify-center sm:w-4/5">
+            <div v-if="!props.library" class="w-full flex justify-center ce-sm:w-4/5">
                 <button
                     class="black-bg-button"
                     @click="setTemplate('json')"
@@ -157,12 +157,11 @@ onMounted(() => {
 <style lang="scss" scoped>
 @media (min-width: 640px) {
     .navbar-wrapper {
-        font-size: 16px;
-        line-height: 24px;
+        @apply text-base;
     }
 }
 
-.black-bg-button {
+.black-bg-button,.white-bg-button {
     @apply flex-1 my-3 mx-1;
 }
 </style>

--- a/src/components/options.vue
+++ b/src/components/options.vue
@@ -12,7 +12,7 @@ const { t } = useI18n();
 
 <template>
     <div>
-        <h1 class="text-2xl font-semibold">{{ t('navbar.options') }}</h1>
+        <h3 class="text-2xl font-semibold">{{ t('navbar.options') }}</h3>
         <Checkbox v-model="store.options!.loadDefaultEvents" checked :title="t('options.defaultEvents')" />
         <Checkbox v-model="store.options!.loadDefaultFixtures" checked :title="t('options.defaultFixtures')" />
         <Checkbox v-model="store.options!.startRequired" :title="t('options.startRequired')" />

--- a/src/components/panels.vue
+++ b/src/components/panels.vue
@@ -34,7 +34,7 @@ const itemFields: Array<Field> = [
 
 <template>
     <div>
-        <h1 class="text-2xl font-semibold">{{ t('navbar.panels') }}</h1>
+        <h3 class="text-2xl font-semibold">{{ t('navbar.panels') }}</h3>
         <Checkbox
             v-model="store.elc.panels!.reorderable"
             checked

--- a/src/components/preview.vue
+++ b/src/components/preview.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="h-full flex flex-col">
-        <h1 class="text-2xl font-semibold">{{ t('navbar.preview') }}</h1>
+        <h3 class="text-2xl font-semibold">{{ t('navbar.preview') }}</h3>
         <p class="mt-3">
             <span class="font-semibold">{{ t('preview.note') }}</span> {{ t('preview.warning') }}
         </p>

--- a/src/components/starting-fixtures.vue
+++ b/src/components/starting-fixtures.vue
@@ -11,15 +11,15 @@ const { t } = useI18n();
 
 <template>
     <div>
-        <h1 class="text-2xl font-semibold">
+        <h3 class="text-2xl font-semibold">
             {{ t('navbar.startingFixtures') }}
-        </h1>
+        </h3>
         <Input
             type="array"
             :title="t('startingFixtures.input')"
             v-model="store.startingFixtures"
             header-class="mt-4"
-            input-class="w-full ce-sm:w-[500px]"
+            input-class="w-full ce-sm:max-w-[500px]"
         />
     </div>
 </template>

--- a/src/components/starting-fixtures.vue
+++ b/src/components/starting-fixtures.vue
@@ -19,7 +19,7 @@ const { t } = useI18n();
             :title="t('startingFixtures.input')"
             v-model="store.startingFixtures"
             header-class="mt-4"
-            input-class="w-full sm:w-[500px]"
+            input-class="w-full ce-sm:w-[500px]"
         />
     </div>
 </template>

--- a/src/components/starting-screen.vue
+++ b/src/components/starting-screen.vue
@@ -1,52 +1,57 @@
 <template>
     <div class="flex flex-col h-full start-container">
         <h2 class="">{{ t('editor.title') }}</h2>
+        <div v-if="!uploading">
         <div class="subtitle">{{ t('start.welcome') }}</div>
-    <div class="flex justify-center items-center">
-        <button class="" @click="newConfig()">
-            <span class="mr-2"
-                ><svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    height="24px"
-                    viewBox="0 -960 960 960"
-                    width="24px"
-                    fill="#434343"
-                >
-                    <path
-                        d="M440-240h80v-120h120v-80H520v-120h-80v120H320v80h120v120ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z"
-                    /></svg></span
-            >{{ t('start.new') }}
-        </button>
-        <span class="separator"></span>
-        <button @click="existingConfig()">
-            <span class="mr-2"
-                ><svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    height="24px"
-                    viewBox="0 -960 960 960"
-                    width="24px"
-                    fill="#434343"
-                >
-                    <path
-                        d="M440-200h80v-167l64 64 56-57-160-160-160 160 57 56 63-63v167ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z"
-                    /></svg></span
-            >{{ t('start.existing') }}
-        </button>
+        <div class="flex justify-center items-center">
+            <button class="" @click="newConfig()">
+                <span class="mr-2"
+                    ><svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        height="24px"
+                        viewBox="0 -960 960 960"
+                        width="24px"
+                        fill="#434343"
+                    >
+                        <path
+                            d="M440-240h80v-120h120v-80H520v-120h-80v120H320v80h120v120ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z"
+                        /></svg></span
+                >{{ t('start.new') }}
+            </button>
+            <span class="separator"></span>
+            <button @click="() => {uploading = true}">
+                <span class="mr-2"
+                    ><svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        height="24px"
+                        viewBox="0 -960 960 960"
+                        width="24px"
+                        fill="#434343"
+                    >
+                        <path
+                            d="M440-200h80v-167l64 64 56-57-160-160-160 160 57 56 63-63v167ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z"
+                        /></svg></span
+                >{{ t('start.existing') }}
+            </button>
+        </div>
+        </div>
+        <uploadScreen v-else @backToStart="uploading = false"></uploadScreen>
     </div>
-    </div>
+    
 </template>
 
 <script setup lang="ts">
 import { API } from '@/index';
 import { useI18n } from 'vue-i18n';
 
+import uploadScreen from './upload-screen.vue';
+import { ref } from 'vue';
+
 const { t } = useI18n();
 
-const newConfig = () => {
-    ((window as any).ramp4EditorAPI as API).initialize();
-};
+let uploading = ref(false);
 
-const existingConfig = () => {
+const newConfig = () => {
     ((window as any).ramp4EditorAPI as API).initialize();
 };
 </script>
@@ -74,7 +79,8 @@ button {
     @apply items-center mx-3 border-black border-solid border px-5 flex w-full justify-center;
     height: 100px;
     outline: none;
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
         background-color: #e7e7e7;
     }
 }

--- a/src/components/starting-screen.vue
+++ b/src/components/starting-screen.vue
@@ -2,42 +2,47 @@
     <div class="flex flex-col h-full start-container">
         <h2 class="">{{ t('editor.title') }}</h2>
         <div v-if="!uploading">
-        <div class="subtitle">{{ t('start.welcome') }}</div>
-        <div class="flex justify-center items-center">
-            <button class="" @click="newConfig()">
-                <span class="mr-2"
-                    ><svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        height="24px"
-                        viewBox="0 -960 960 960"
-                        width="24px"
-                        fill="#434343"
-                    >
-                        <path
-                            d="M440-240h80v-120h120v-80H520v-120h-80v120H320v80h120v120ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z"
-                        /></svg></span
-                >{{ t('start.new') }}
-            </button>
-            <span class="separator"></span>
-            <button @click="() => {uploading = true}">
-                <span class="mr-2"
-                    ><svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        height="24px"
-                        viewBox="0 -960 960 960"
-                        width="24px"
-                        fill="#434343"
-                    >
-                        <path
-                            d="M440-200h80v-167l64 64 56-57-160-160-160 160 57 56 63-63v167ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z"
-                        /></svg></span
-                >{{ t('start.existing') }}
-            </button>
-        </div>
+            <div class="subtitle">{{ t('start.welcome') }}</div>
+            <div class="flex justify-center items-center">
+                <button class="" @click="newConfig()">
+                    <span class="mr-2"
+                        ><svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            height="24px"
+                            viewBox="0 -960 960 960"
+                            width="24px"
+                            fill="#434343"
+                        >
+                            <path
+                                d="M440-240h80v-120h120v-80H520v-120h-80v120H320v80h120v120ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z"
+                            /></svg></span
+                    >{{ t('start.new') }}
+                </button>
+                <span class="separator"></span>
+                <button
+                    @click="
+                        () => {
+                            uploading = true;
+                        }
+                    "
+                >
+                    <span class="mr-2"
+                        ><svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            height="24px"
+                            viewBox="0 -960 960 960"
+                            width="24px"
+                            fill="#434343"
+                        >
+                            <path
+                                d="M440-200h80v-167l64 64 56-57-160-160-160 160 57 56 63-63v167ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z"
+                            /></svg></span
+                    >{{ t('start.existing') }}
+                </button>
+            </div>
         </div>
         <uploadScreen v-else @backToStart="uploading = false"></uploadScreen>
     </div>
-    
 </template>
 
 <script setup lang="ts">

--- a/src/components/system.vue
+++ b/src/components/system.vue
@@ -22,14 +22,14 @@ const { t } = useI18n();
             :description="t('system.proxyUrl.description')"
             v-model="store.elc.system!.proxyUrl"
             header-class="mt-4"
-            input-class="w-full sm:w-[500px]"
+            input-class="w-full ce-sm:w-[500px]"
         />
         <Input
             :title="t('system.zoomIcon.title')"
             :description="t('system.zoomIcon.description')"
             v-model="store.elc.system!.zoomIcon"
             header-class="mt-4"
-            input-class="w-full sm:w-[500px]"
+            input-class="w-full ce-sm:w-[500px]"
         />
         <Checkbox
             v-model="store.elc.system!.animate"

--- a/src/components/system.vue
+++ b/src/components/system.vue
@@ -16,20 +16,20 @@ const { t } = useI18n();
 
 <template>
     <div>
-        <h1 class="text-2xl font-semibold">{{ t('navbar.system') }}</h1>
+        <h3 class="text-2xl font-semibold">{{ t('navbar.system') }}</h3>
         <Input
             :title="t('system.proxyUrl.title')"
             :description="t('system.proxyUrl.description')"
             v-model="store.elc.system!.proxyUrl"
             header-class="mt-4"
-            input-class="w-full ce-sm:w-[500px]"
+            input-class="w-full ce-sm:max-w-[500px]"
         />
         <Input
             :title="t('system.zoomIcon.title')"
             :description="t('system.zoomIcon.description')"
             v-model="store.elc.system!.zoomIcon"
             header-class="mt-4"
-            input-class="w-full ce-sm:w-[500px]"
+            input-class="w-full ce-sm:max-w-[500px]"
         />
         <Checkbox
             v-model="store.elc.system!.animate"

--- a/src/components/upload-screen.vue
+++ b/src/components/upload-screen.vue
@@ -59,6 +59,11 @@
             </div>
         </div>
 
+        <div v-if="errorMessage !== ''" class="flex py-8 mt-8 bg-red-300">
+            <span class="ml-auto" role="alert">{{ errorMessage }}</span>
+            <button class="ml-auto px-4" @click="errorMessage = ''"><svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#434343"><path d="m256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z"/></svg></button>
+        </div>
+
         <div class="flex">
             <button class="continue-button max-w-[200px] ml-auto mt-40" :disabled="!jsonText" @click="startEditor">
                 {{ $t('upload.continue') }}
@@ -71,10 +76,14 @@
 import { ref } from 'vue';
 import { API } from '@/index';
 import { RampConfigs } from '@/definitions';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 
 const fileInput = ref<HTMLInputElement | null>(null);
 const parsedData = ref<unknown>(null);
 const jsonText = ref<string>('');
+const errorMessage = ref<string>('');
 
 const handleDrop = (event: DragEvent): void => {
     const files = event.dataTransfer?.files;
@@ -141,7 +150,11 @@ const handleTextInput = (): void => {
 };
 
 const startEditor = () => {
-    ((window as any).ramp4EditorAPI as API).initialize(parsedData.value as RampConfigs);
+    try {
+        ((window as any).ramp4EditorAPI as API).initialize(parsedData.value as RampConfigs);    
+    } catch (error) {
+        errorMessage.value = t('upload.error.configs');
+    }
 };
 </script>
 

--- a/src/components/upload-screen.vue
+++ b/src/components/upload-screen.vue
@@ -11,6 +11,8 @@
                 <div
                     class="rounded-[8px] p-40 text-center bg-gray-100 border-dashed border-2 border-gray-400 h-full content-center"
                     tabindex="0"
+                    @dragover.prevent
+                    @dragleave.prevent
                     @drop.prevent="handleDrop"
                 >
                     <div class="flex flex-col items-center">

--- a/src/components/upload-screen.vue
+++ b/src/components/upload-screen.vue
@@ -61,7 +61,7 @@
 
         <div v-if="errorMessage !== ''" class="flex py-8 mt-8 bg-red-300">
             <span class="ml-auto" role="alert">{{ errorMessage }}</span>
-            <button class="ml-auto px-4" @click="errorMessage = ''"><svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#434343"><path d="m256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z"/></svg></button>
+            <button class="ml-auto px-4" @click="errorMessage = ''" :aria-label="errorMessage"><svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#434343"><path d="m256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z"/></svg></button>
         </div>
 
         <div class="flex">
@@ -150,6 +150,10 @@ const handleTextInput = (): void => {
 };
 
 const startEditor = () => {
+    if (!parsedData.value) {
+        errorMessage.value = t('upload.error.invalidJSON');
+        return;
+    }
     try {
         ((window as any).ramp4EditorAPI as API).initialize(parsedData.value as RampConfigs);
     } catch (error) {

--- a/src/components/upload-screen.vue
+++ b/src/components/upload-screen.vue
@@ -1,0 +1,159 @@
+<template>
+    <div class="flex flex-col w-full p-20">
+        <button @click="$emit('backToStart')" class="mr-auto w-auto flex px-4 py-12 mb-8">
+            <svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="24px" fill="#434343">
+                <path d="m313-440 224 224-57 56-320-320 320-320 57 56-224 224h487v80H313Z" />
+            </svg>
+            {{ $t('upload.back') }}
+        </button>
+        <div class="flex">
+            <div class="flex flex-col w-1/2">
+                <div
+                    class="rounded-[8px] p-40 text-center bg-gray-100 border-dashed border-2 border-gray-400 h-full content-center"
+                    tabindex="0"
+                    @drop.prevent="handleDrop"
+                >
+                    <div class="flex flex-col items-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 -2 30 30">
+                        <path
+                            d="M599,692 C597.896,692 597,692.896 597,694 L597,698 L575,698 L575,694 C575,692.896 574.104,692 573,692 C571.896,692 571,692.896 571,694 L571,701 C571,701.479 571.521,702 572,702 L600,702 C600.604,702 601,701.542 601,701 L601,694 C601,692.896 600.104,692 599,692 L599,692 Z M582,684 L584,684 L584,693 C584,694.104 584.896,695 586,695 C587.104,695 588,694.104 588,693 L588,684 L590,684 C590.704,684 591.326,684.095 591.719,683.7 C592.11,683.307 592.11,682.668 591.719,682.274 L586.776,676.283 C586.566,676.073 586.289,675.983 586.016,675.998 C585.742,675.983 585.465,676.073 585.256,676.283 L580.313,682.274 C579.921,682.668 579.921,683.307 580.313,683.7 C580.705,684.095 581.608,684 582,684 L582,684 Z"
+                            transform="translate(-571.000000, -676.000000)"
+                        />
+                    </svg>
+                        <p class=" pt-16 text-xl">{{ $t('upload.file.drag') }}</p>
+                        <p>{{ $t('upload.file.separator') }}</p>
+                        <!-- file upload button -->
+                        <div class="mt-16">
+                            <button
+                                class="bg-white border rounded-[4px] border-black hover:bg-gray-100 font-bold p-16"
+                                @click="fileInput?.click()"
+                            >
+                                {{ $t('upload.file.click') }}
+                            </button>
+                            <input
+                                ref="fileInput"
+                                type="file"
+                                class="hidden"
+                                @change="handleFileSelect"
+                                accept=".json"
+                                tabindex="-1"
+                                :aria-label="$t('upload.file.aria')"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <span class="w-40"></span>
+
+            <div class="flex w-1/2">
+                <textarea
+                    v-model="jsonText"
+                    class="p-12 w-full text-xs border border-solid rounded-[8px] font-mono"
+                    :placeholder="$t('upload.input.placeholder')"
+                    @input="handleTextInput"
+                    :aria-label="$t('upload.input.aria')"
+                />
+            </div>
+        </div>
+
+        <div class="flex">
+            <button class="continue-button max-w-[200px] ml-auto mt-40" :disabled="!jsonText" @click="startEditor">
+                {{ $t('upload.continue') }}
+            </button>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { API } from '@/index';
+import { RampConfigs } from '@/definitions';
+
+const fileInput = ref<HTMLInputElement | null>(null);
+const parsedData = ref<unknown>(null);
+const jsonText = ref<string>('');
+
+const handleDrop = (event: DragEvent): void => {
+    const files = event.dataTransfer?.files;
+    if (files?.length) {
+        handleFiles(files);
+    }
+};
+
+const handleFileSelect = (event: Event): void => {
+    const target = event.target as HTMLInputElement;
+    if (target.files?.length) {
+        handleFiles(target.files);
+    }
+};
+
+const handleFiles = (files: FileList): void => {
+    if (files.length > 0) {
+        const file = files[0];
+        if (!file.name.endsWith('.json')) {
+            return;
+        }
+        readAndParseJSON(file);
+    }
+};
+
+const readAndParseJSON = async (file: File): Promise<void> => {
+    try {
+        const text = await new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = e => {
+                const result = e.target?.result;
+                if (typeof result === 'string') {
+                    resolve(result);
+                } else {
+                    reject(new Error('Failed to read file'));
+                }
+            };
+            reader.onerror = () => reject(new Error('File reading error'));
+            reader.readAsText(file);
+        });
+
+        jsonText.value = text;
+        parseJSON(text);
+    } catch (error) {
+        parsedData.value = null;
+    }
+};
+
+const parseJSON = (text: string): void => {
+    try {
+        const data = JSON.parse(text);
+        parsedData.value = data;
+    } catch (error) {
+        parsedData.value = null;
+    }
+};
+
+const handleTextInput = (): void => {
+    if (jsonText.value.trim()) {
+        parseJSON(jsonText.value);
+    } else {
+        parsedData.value = null;
+    }
+};
+
+const startEditor = () => {
+    ((window as any).ramp4EditorAPI as API).initialize(parsedData.value as RampConfigs);
+};
+</script>
+
+<style scoped lang="scss">
+.continue-button {
+    @apply items-center mx-3 border-black border-solid border px-5 flex w-full justify-center cursor-pointer h-48;
+    outline: none;
+    &:disabled {
+        @apply border-gray-400 text-gray-500 cursor-not-allowed;
+    }
+
+    &:hover:enabled,
+    &:focus:enabled {
+        background-color: #e7e7e7;
+    }
+}
+</style>

--- a/src/components/upload-screen.vue
+++ b/src/components/upload-screen.vue
@@ -151,7 +151,7 @@ const handleTextInput = (): void => {
 
 const startEditor = () => {
     try {
-        ((window as any).ramp4EditorAPI as API).initialize(parsedData.value as RampConfigs);    
+        ((window as any).ramp4EditorAPI as API).initialize(parsedData.value as RampConfigs);
     } catch (error) {
         errorMessage.value = t('upload.error.configs');
     }

--- a/src/config-editor.vue
+++ b/src/config-editor.vue
@@ -1,25 +1,23 @@
 <template>
     <div class="ramp4-config-editor h-full">
-        <StartingScreen v-if="!store.initialized && !library" />
-        <div v-else class="h-full flex flex-col">
-            <div class="flex items-center">
-                <h2 class="h-9 text-3xl font-semibold">{{ t('editor.title') }}</h2>
-                <span class="ml-auto"></span>
-                <button
-                    v-if="!library"
-                    class="black-bg-button"
-                    @click="() => createNew()"
-                >
-                    {{ t('editor.new') }}
-                </button>
-            </div>
-            <div class="main-container flex-grow mt-3 flex">
-                <Navbar class="config-navbar h-full flex-shrink-0" :library="library" />
-                <div class="flex-grow h-full pl-5 overflow-y-auto">
-                    <div v-if="store.editingTemplate === ''">
-                        {{ t('editor.startEditing') }}
+        <div ref="app-size" class="h-full">
+            <StartingScreen v-if="!store.initialized && !library" />
+            <div v-else class="h-full flex flex-col">
+                <div class="flex items-center">
+                    <h2 class="h-36 text-3xl font-semibold">{{ t('editor.title') }}</h2>
+                    <span class="ml-auto"></span>
+                    <button v-if="!library" class="black-bg-button" @click="() => createNew()">
+                        {{ t('editor.new') }}
+                    </button>
+                </div>
+                <div class="main-container flex-grow mt-12 flex">
+                    <Navbar class="config-navbar h-full flex-shrink-0" :library="library" />
+                    <div class="flex-grow h-full pl-20 overflow-y-auto">
+                        <div v-if="store.editingTemplate === ''">
+                            {{ t('editor.startEditing') }}
+                        </div>
+                        <component v-else :is="editors[store.editingTemplate]"></component>
                     </div>
-                    <component v-else :is="editors[store.editingTemplate]"></component>
                 </div>
             </div>
         </div>
@@ -41,16 +39,20 @@ import SystemEditor from '@/components/system.vue';
 import OptionsEditor from '@/components/options.vue';
 import Preview from '@/components/preview.vue';
 
+import CustomResizeObserver from './scripts/resize-observer';
+
 import '@/styles.css';
 import 'ramp-pcar/dist/ramp.css';
 import { useI18n } from 'vue-i18n';
-import { onMounted } from 'vue';
+import { onMounted, useTemplateRef } from 'vue';
 import { setDefaultProps } from 'vue-tippy';
 import { useStore } from '@/store';
 
 const { t } = useI18n();
 const store = useStore();
 let library: boolean = false;
+
+const appSizeContainer = useTemplateRef('app-size');
 
 const editors: { [key: string]: any } = {
     fixtures: FixturesEditor,
@@ -83,6 +85,12 @@ onMounted(() => {
         offset: [0, 5]
     });
 
+    // Puts `ce-xs` `ce-sm` `ce-md` `ce-lg` classes on the container, used instead of window sizes because this app can live inside other pages/apps
+    // `ce` (config-editor) prefix is to prevent styles bleeding into nest RAMP instances. sm:m-20 would apply to the RAMP component based on the editors size instead.
+    const ro = new CustomResizeObserver();
+    ro.observe(appSizeContainer.value!);
+
+    // Used to turn off certain UI elements in library mode.
     if (import.meta.env.MODE.includes('lib')) {
         library = true;
     }
@@ -143,19 +151,14 @@ $font-list: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica
         input[type='text'],
         input[type='number'],
         select {
-            @apply w-full p-2;
+            width: 100%;
+            padding: 4px;
         }
     }
 
     .required:after {
         content: ' *';
         color: red;
-    }
-
-    .ramp-styles {
-        .p-5 {
-            padding: 5px;
-        }
     }
 
     .config-navbar {
@@ -167,7 +170,19 @@ $font-list: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica
     }
 
     .black-bg-button {
-        @apply bg-black text-white p-2 rounded-md;
+        @apply bg-black text-white p-8 rounded-[4px];
+        outline: none;
+        border-width: 1px;
+        border-color: #000;
+        &:hover,
+        &:focus {
+            background-color: rgba(209, 213, 219, 1);
+            color: black;
+        }
+    }
+
+    .white-bg-button {
+        @apply  p-8 rounded-[4px];
         outline: none;
         border-width: 1px;
         border-color: #000;

--- a/src/config-editor.vue
+++ b/src/config-editor.vue
@@ -103,6 +103,8 @@ $font-list: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica
 
 .ramp4-config-editor {
     height: 100%;
+    width: 100%;
+    
     font-family: $font-list;
     h1,
     h2,
@@ -142,7 +144,7 @@ $font-list: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica
         );
         column-gap: var(--grid-layout-gap);
         row-gap: 16px;
-
+    
         select,
         input {
             @apply block border border-black text-sm;
@@ -166,7 +168,7 @@ $font-list: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica
     }
 
     .main-container {
-        height: calc(100% - 40px);
+        height: calc(100% - 60px);
     }
 
     .black-bg-button {

--- a/src/default-config.json
+++ b/src/default-config.json
@@ -564,11 +564,6 @@
                 "root": {
                     "name": "root",
                     "children": [
-                        {
-                            "layerId": "",
-                            "symbologyExpanded": true,
-                            "entryIndex": 0
-                        }
                     ]
                 },
                 "headerControls": ["groupToggle", "visibilityToggle", "layerReorder"]
@@ -1173,11 +1168,6 @@
                 "root": {
                     "name": "root",
                     "children": [
-                        {
-                            "layerId": "",
-                            "symbologyExpanded": true,
-                            "entryIndex": 0
-                        }
                     ]
                 },
                 "headerControls": ["groupToggle", "visibilityToggle", "layerReorder"]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { createApp as createVueApp } from 'vue';
+import { createApp as createVueApp, toRaw } from 'vue';
 import type { ComponentPublicInstance } from 'vue';
 import { createPinia } from 'pinia';
 import { i18n } from './lang';
@@ -100,7 +100,8 @@ export const createInstance = (el: HTMLElement, config?: RampConfigs | undefined
  */
 const maptipMigrator = (configNugget: RampConfig): RampConfig => {
     // copy, so we don't mangle the source object
-    const con = structuredClone(configNugget);
+    // have to `toRaw` the config as its reactive and structureClone fails
+    const con = structuredClone(toRaw(configNugget));
 
     // find layer configs
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,8 @@ export class API {
                 const cleanedLangConfig = maptipMigrator(configs.configs[lang]);
                 store.configs[lang] = merge(defaultConfig[lang as 'en'], cleanedLangConfig);
             });
+        } else if (configs) {
+            throw new Error('Invalid config format');
         } else {
             store.configs = defaultConfig;
         }

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -18,6 +18,7 @@ upload.file.aria,"Config file upload",1,"Config file upload",0
 upload.input.placeholder,"Paste your config or upload a file to the left",1,"Paste your config or upload a file to the left",0
 upload.input.aria,"Config file text input",1,"Config file text input",0
 upload.error.configs,"Invalid config format: no 'configs' object",1,"Format de configuration invalide : aucun objet 'configs'",0
+upload.error.invalidJSON,"Invalid JSON provided",1,"JSON invalide fourni",0
 upload.continue,Start editing,1,Start editing,0
 upload.back,Back,1,Back,0
 navbar.startingFixtures,Starting Fixtures,1,Calendrier de départ,1

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -17,6 +17,7 @@ upload.file.click,"Click to choose a file",1,"Click to choose a file",0
 upload.file.aria,"Config file upload",1,"Config file upload",0
 upload.input.placeholder,"Paste your config or upload a file to the left",1,"Paste your config or upload a file to the left",0
 upload.input.aria,"Config file text input",1,"Config file text input",0
+upload.error.configs,"Invalid config format: no 'configs' object",1,"Format de configuration invalide : aucun objet 'configs'",0
 upload.continue,Start editing,1,Start editing,0
 upload.back,Back,1,Back,0
 navbar.startingFixtures,Starting Fixtures,1,Calendrier de départ,1

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -10,6 +10,15 @@ editor.startEditing,Use the table of contents on the left to start editing.,1,Us
 start.new,Create new config,1,Create new config,0
 start.existing,Use existing config,1,Use existing config,0
 start.welcome,What would you like to do?,1,Qu'aimeriez-vous faire?,0
+upload.file,"Load from file",1,"Load from file",0
+upload.file.drag,"Drag your config file here",1,"Drag your config file here",0
+upload.file.separator,or,1,or,0
+upload.file.click,"Click to choose a file",1,"Click to choose a file",0
+upload.file.aria,"Config file upload",1,"Config file upload",0
+upload.input.placeholder,"Paste your config or upload a file to the left",1,"Paste your config or upload a file to the left",0
+upload.input.aria,"Config file text input",1,"Config file text input",0
+upload.continue,Start editing,1,Start editing,0
+upload.back,Back,1,Back,0
 navbar.startingFixtures,Starting Fixtures,1,Calendrier de départ,1
 navbar.configs,Configs,1,Configurations,1
 navbar.options,Options,1,Options,1

--- a/src/scripts/resize-observer.ts
+++ b/src/scripts/resize-observer.ts
@@ -1,0 +1,48 @@
+// From https://philipwalton.com/articles/responsive-components-a-solution-to-the-container-queries-problem/
+
+// Create a single ResizeObserver class to handle all
+// container elements. The instance is created with a callback,
+// which is invoked as soon as an element is observed as well
+// as any time that element's size changes.
+
+const DEFAULT_BREAKPOINTS = {
+    xs: 200,
+    sm: 576,
+    md: 768,
+    lg: 960
+};
+
+export default class CustomResizeObserver {
+    private readonly resizeObserver: ResizeObserver;
+
+    constructor(breakpoints?: { [key: string]: number }) {
+        this.resizeObserver = new ResizeObserver(entries => {
+            if (!entries.length) {
+                return;
+            }
+
+            // Use requestAnimationFrame to ensure the callback runs after the browser paints to avoid
+            // a console error for undelivered notifications. This error occurs because we are adding a class to the target
+            // element, possibly before draw, and the browser is warning that an infinite loop is possible (if the class were to trigger a resize).
+            window.requestAnimationFrame(() => {
+                entries.forEach(entry => {
+                    const customData = (entry.target as HTMLElement).dataset.breakpoints;
+                    const bp = customData ? JSON.parse(customData) : (breakpoints ?? DEFAULT_BREAKPOINTS);
+
+                    Object.keys(bp).forEach(key => {
+                        const minWidth = bp[key];
+                        if (entry.contentRect.width >= minWidth) {
+                            entry.target.classList.add(key);
+                        } else {
+                            entry.target.classList.remove(key);
+                        }
+                    });
+                });
+            });
+        });
+    }
+
+    observe(target: Element): void {
+        this.resizeObserver?.observe(target);
+    }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -28,6 +28,10 @@
             cursor: pointer;
             color: black;
         }
+        select {
+            background-image: unset;
+            appearance: auto !important;
+        }
     }
 
     @layer utilities {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,10 +5,19 @@
     @tailwind variants;
 
     @layer base {
+        input[type='text']{
+            display: block;
+            border-width: 1px;
+            border-color: black;
+            font-size: 14px;
+            line-height: 20px;
+        }
         input[type='checkbox'] {
             border-width: 2px;
             border-color: black;
             margin-right: 8px;
+            width: 16px;
+            height: 16px;
             cursor: pointer;
             color: black;
         }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,8 +1,109 @@
-/** @type {import('tailwindcss').Config} */
+/* eslint-disable @typescript-eslint/no-require-imports */
+const plugin = require('tailwindcss/plugin');
 module.exports = {
     content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
     theme: {
-        extend: {}
+        // remove all breakpoints because ramp components will depend on the shell size, not the size of the window/page
+        screens: {
+            // sm: '640px'
+        },
+        fontSize: {
+            xs: ['12px', '16px'],
+            sm: ['14px', '20px'],
+            base: ['16px', '24px'],
+            lg: ['18px', '28px'],
+            xl: ['20px', '28px'],
+            '2xl': ['24px', '32px'],
+            '3xl': ['30px', '36px'],
+            '4xl': ['36px', '40px'],
+            '5xl': '48px',
+            '6xl': '60px',
+            '7xl': '72px',
+            '8xl': '96px',
+            '9xl': '128px'
+        },
+        spacing: {
+            '-36': '-36px',
+            '-32': '-32px',
+            '-30': '-30px',
+            '-2': '-2px',
+            0: '0px',
+            1: '1px',
+            2: '2px',
+            3: '3px',
+            4: '4px',
+            5: '5px',
+            6: '6px',
+            7: '7px',
+            8: '8px',
+            9: '9px',
+            10: '10px',
+            12: '12px',
+            14: '14px',
+            15: '15px',
+            16: '16px',
+            18: '18px',
+            20: '20px',
+            24: '24px',
+            25: '25px',
+            26: '26px',
+            28: '28px',
+            29: '29px',
+            30: '30px',
+            32: '32px',
+            36: '36px',
+            38: '38px',
+            40: '40px',
+            42: '42px',
+            44: '44px',
+            46: '46px',
+            48: '48px',
+            56: '56px',
+            64: '64px',
+            75: '75px',
+            80: '80px',
+            100: '100px',
+            116: '116px',
+            160: '160px',
+            180: '180px',
+            192: '192px',
+            230: '230px',
+            256: '256px',
+            500: '500px'
+        },
+        extend: {
+            inset: {
+                '-9': '-9px',
+                1: '1px',
+                32: '32px',
+                64: '64px',
+                200: '200px',
+                '1/2': '50%',
+                '9/20': '45%',
+                full: '100%'
+            },
+            colors: {
+                'black-75': 'rgba(0, 0, 0, 0.75)',
+                'white-75': 'rgba(255, 255, 255, 0.75)',
+                'grey-test': 'rgba(150,150,150,0.7);'
+            },
+            boxShadow: {
+                tm: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 2px 3px 0 rgba(0, 0, 0, 0.1)'
+            },
+            cursor: {
+                grab: 'grab'
+            }
+        }
     },
-    plugins: [require('@tailwindcss/forms')]
+    plugins: [
+        plugin(function ({ addVariant }) {
+            addVariant('ce-xs', '.xs &');
+            addVariant('ce-sm', '.sm &');
+            addVariant('ce-md', '.md &');
+            addVariant('ce-lg', '.lg &');
+        }),
+        require('@tailwindcss/forms')({
+            strategy: 'base' // only generate global styles
+        })
+    ]
 };


### PR DESCRIPTION
### Related Item(s)

#124 #112 

### Changes

- [FEATURE] upload screen added; supports drag and drop, selecting a file and pasting in JSON
- [FEATURE] now uses the same resize-observer as RAMP to handle styles while embedded in a page or other app (RESPECT)
- [REFACTOR/FIX] fixes tailwind config issues, current config is based on RAMP

### Notes

I still need to finish up small screen styles for RESPECT integration, hopefully will have that in another PR soon™️

### Testing

Poke around the app and see if anything looks strange

Upload screen:
1. Click on existing config on the landing page
2. Try different ways to upload a config
3. Click start editing and see your config being used

[Sample config](https://github.com/user-attachments/files/24766974/RAMP_PCAR-ECCC-default-config.json)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/config-editor/128)
<!-- Reviewable:end -->
