### PR TITLE
Remove spaces from urls in default config

### DIFF
--- a/src/default-config.json
+++ b/src/default-config.json
@@ -267,7 +267,7 @@
                         {
                             "id": "CBMT",
                             "layerType": "esri-tile",
-                            "url": "https: //maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer",
+                            "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer",
                             "opacity": 1
                         }
                     ],
@@ -292,7 +292,7 @@
                         {
                             "id": "SMR",
                             "layerType": "esri-tile",
-                            "url": "https: //maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer",
+                            "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer",
                             "opacity": 1
                         }
                     ],
@@ -316,7 +316,7 @@
                         {
                             "id": "CBME_CBCE_HS_RO_3978",
                             "layerType": "esri-tile",
-                            "url": "https: //maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer",
+                            "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer",
                             "opacity": 1
                         }
                     ],
@@ -340,7 +340,7 @@
                         {
                             "id": "CBMT_CBCT_GEOM_3978",
                             "layerType": "esri-tile",
-                            "url": "https: //maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer",
+                            "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer",
                             "opacity": 1
                         }
                     ],
@@ -365,7 +365,7 @@
                         {
                             "id": "provinces_3978",
                             "layerType": "esri-tile",
-                            "url": "https: //maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer"
+                            "url": "https://maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer"
                         }
                     ],
                     "attribution": {
@@ -389,7 +389,7 @@
                         {
                             "id": "World_Imagery",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -404,7 +404,7 @@
                         {
                             "id": "World_Physical_Map",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -419,7 +419,7 @@
                         {
                             "id": "World_Shaded_Relief",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -434,7 +434,7 @@
                         {
                             "id": "World_Street_Map",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -449,7 +449,7 @@
                         {
                             "id": "World_Terrain_Base",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -464,7 +464,7 @@
                         {
                             "id": "World_Topo_Map",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -485,10 +485,10 @@
         "fixtures": {
             "geosearch": {
                 "serviceUrls": {
-                    "geoNames": "https: //geogratis.gc.ca/services/geoname/en/geonames.json",
-                    "geoLocation": "https: //geogratis.gc.ca/services/geolocation/en/locate?q=",
-                    "geoProvince": "https: //geogratis.gc.ca/services/geoname/en/codes/province.json",
-                    "geoTypes": "https: //geogratis.gc.ca/services/geoname/en/codes/concise.json"
+                    "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                    "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                    "geoProvince": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                    "geoTypes": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
                 },
                 "settings": {
                     "categories": [
@@ -599,7 +599,7 @@
             "animate": true,
             "exposeOid": false,
             "exposeMeasurements": true,
-            "proxyUrl": "https: //maps.canada.ca/wmsproxy/ws/wmsproxy/executeFromProxy"
+            "proxyUrl": "https://maps.canada.ca/wmsproxy/ws/wmsproxy/executeFromProxy"
         },
         "version": "4.0"
     },
@@ -871,7 +871,7 @@
                         {
                             "id": "CBCT",
                             "layerType": "esri-tile",
-                            "url": "https: //maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBCT3978/MapServer",
+                            "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBCT3978/MapServer",
                             "opacity": 1
                         }
                     ],
@@ -896,13 +896,13 @@
                         {
                             "id": "SMR",
                             "layerType": "esri-tile",
-                            "url": "https: //maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer",
+                            "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer",
                             "opacity": 1
                         },
                         {
                             "id": "SMW",
                             "layerType": "esri-tile",
-                            "url": "https: //maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
+                            "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
                         }
                     ],
                     "attribution": {
@@ -925,7 +925,7 @@
                         {
                             "id": "CBME_CBCE_HS_RO_3978",
                             "layerType": "esri-tile",
-                            "url": "https: //maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer",
+                            "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer",
                             "opacity": 1
                         }
                     ],
@@ -949,7 +949,7 @@
                         {
                             "id": "CBMT_CBCT_GEOM_3978",
                             "layerType": "esri-tile",
-                            "url": "https: //maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer",
+                            "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer",
                             "opacity": 1
                         }
                     ],
@@ -974,7 +974,7 @@
                         {
                             "id": "provinces_3978",
                             "layerType": "esri-tile",
-                            "url": "https: //maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer"
+                            "url": "https://maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer"
                         }
                     ],
                     "attribution": {
@@ -998,7 +998,7 @@
                         {
                             "id": "World_Imagery",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -1013,7 +1013,7 @@
                         {
                             "id": "World_Physical_Map",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -1028,7 +1028,7 @@
                         {
                             "id": "World_Shaded_Relief",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -1043,7 +1043,7 @@
                         {
                             "id": "World_Street_Map",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -1058,7 +1058,7 @@
                         {
                             "id": "World_Terrain_Base",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -1073,7 +1073,7 @@
                         {
                             "id": "World_Topo_Map",
                             "layerType": "esri-tile",
-                            "url": "https: //services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer",
+                            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer",
                             "opacity": 1
                         }
                     ]
@@ -1094,10 +1094,10 @@
         "fixtures": {
             "geosearch": {
                 "serviceUrls": {
-                    "geoNames": "https: //geogratis.gc.ca/services/geoname/fr/geonames.json",
-                    "geoLocation": "https: //geogratis.gc.ca/services/geolocation/fr/locate?q=",
-                    "geoProvince": "https: //geogratis.gc.ca/services/geoname/fr/codes/province.json",
-                    "geoTypes": "https: //geogratis.gc.ca/services/geoname/fr/codes/concise.json"
+                    "geoNames": "https://geogratis.gc.ca/services/geoname/fr/geonames.json",
+                    "geoLocation": "https://geogratis.gc.ca/services/geolocation/fr/locate?q=",
+                    "geoProvince": "https://geogratis.gc.ca/services/geoname/fr/codes/province.json",
+                    "geoTypes": "https://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
                 },
                 "settings": {
                     "categories": [
@@ -1206,7 +1206,7 @@
             "animate": true,
             "exposeOid": false,
             "exposeMeasurements": true,
-            "proxyUrl": "https: //maps.canada.ca/wmsproxy/ws/wmsproxy/executeFromProxy"
+            "proxyUrl": "https://maps.canada.ca/wmsproxy/ws/wmsproxy/executeFromProxy"
         },
         "version": "4.0"
     }


### PR DESCRIPTION
#138 

### Changes

- [FIX] removes the evil extra spaces from various urls in the default config

### Notes

This is also fixed in #136 but it is causing issues in the deployed version of the config editor so its better to decouple the changes.

### Testing

Steps:

1. Look at the config
2. Preview the default map if you desire

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/config-editor/143)
<!-- Reviewable:end -->
